### PR TITLE
Add URL audio loading

### DIFF
--- a/index.html
+++ b/index.html
@@ -40,6 +40,7 @@
                             <strong>Drop or Click</strong>
                             Add MP3/WAV file
                         </div>
+                        <button class="url-btn" onclick="promptLoadFromUrl(0)">Load from URL</button>
                     </div>
                 </div>
             </div>

--- a/style.css
+++ b/style.css
@@ -485,6 +485,22 @@ body {
     margin-bottom: 5px;
 }
 
+.url-btn {
+    margin-top: 10px;
+    padding: 6px 12px;
+    border: none;
+    border-radius: 6px;
+    cursor: pointer;
+    font-size: 12px;
+    background: #555;
+    color: #fff;
+    transition: background 0.2s ease;
+}
+
+.url-btn:hover {
+    background: #666;
+}
+
 .remove-sound {
     position: absolute;
     top: 5px;


### PR DESCRIPTION
## Summary
- allow loading audio from a URL
- create `Load from URL` button on empty slots
- style new button

## Testing
- `node --check script.js`


------
https://chatgpt.com/codex/tasks/task_e_687afd581888832f93efd00ae612bc8c