### PR TITLE
Remove spinners from volume input

### DIFF
--- a/style.css
+++ b/style.css
@@ -468,6 +468,14 @@ body {
     font-size: 10px;
     padding: 2px 4px;
     text-align: center;
+    /* Hide number input spinners across browsers */
+    -moz-appearance: textfield;
+}
+
+.volume-number::-webkit-inner-spin-button,
+.volume-number::-webkit-outer-spin-button {
+    -webkit-appearance: none;
+    margin: 0;
 }
 
 .empty-slot {


### PR DESCRIPTION
## Summary
- hide the browser default spinner on volume number fields

## Testing
- `git status --short`

------
https://chatgpt.com/codex/tasks/task_e_687b14e472b8832f9334e9fce0b3d7a1