### PR TITLE
Add import/export feature

### DIFF
--- a/README.md
+++ b/README.md
@@ -11,5 +11,6 @@ A browser-based soundboard for quickly loading and playing audio clips. Sounds c
 5. Create additional tabs for different groups of sounds.
 6. The "Library" button shows previously added files saved in your browser.
 7. Within the library you can rename or delete stored files (you'll be warned if a file is used in any tab).
+8. Use the Export/Import buttons to backup or restore your entire board as a JSON file.
 
 Saved state is stored in `localStorage` and audio files are kept in IndexedDB so they persist between sessions.

--- a/index.html
+++ b/index.html
@@ -21,6 +21,9 @@
                 <button class="btn" onclick="stopAllSounds()">Stop All</button>
                 <button class="btn danger" onclick="clearCurrentPanel()">Clear Panel</button>
                 <button class="btn" onclick="openLibrary()">Library</button>
+                <button class="btn" onclick="exportBoard()">Export</button>
+                <button class="btn" onclick="triggerImport()">Import</button>
+                <input type="file" id="importInput" accept=".json" class="hidden" onchange="handleImportFile(this)">
             </div>
         </div>
 

--- a/storage.js
+++ b/storage.js
@@ -58,6 +58,19 @@ const storage = (() => {
         });
     }
 
-    return { put, get, remove };
+    async function clear() {
+        const db = await openDB();
+        return new Promise((resolve, reject) => {
+            const tx = db.transaction(STORE_NAME, 'readwrite');
+            const req = tx.objectStore(STORE_NAME).clear();
+            req.onsuccess = () => resolve();
+            req.onerror = () => {
+                console.error('IndexedDB clear error', req.error);
+                reject(req.error);
+            };
+        });
+    }
+
+    return { put, get, remove, clear };
 })();
 


### PR DESCRIPTION
## Summary
- allow downloading full board state with audio files as JSON
- enable restoring board data from previously exported file
- add buttons for import/export actions
- document backup functionality

## Testing
- `node -v`

------
https://chatgpt.com/codex/tasks/task_e_687b199aee94832fa2917f93531632de