### PR TITLE
Fix loading sounds when button-created input triggers action

### DIFF
--- a/script.js
+++ b/script.js
@@ -244,8 +244,15 @@ async function loadSound(input, tabId, isTemporary = false) {
 
         // Replace the empty slot
         const grid = document.getElementById(`grid-${tabId}`);
-        const emptySlot = input.closest('.empty-slot');
-        emptySlot.replaceWith(soundCard);
+        let emptySlot = input.closest('.empty-slot');
+        if (!emptySlot) {
+            emptySlot = grid.querySelector('.empty-slot');
+        }
+        if (emptySlot) {
+            emptySlot.replaceWith(soundCard);
+        } else {
+            grid.appendChild(soundCard);
+        }
 
         // Create new empty slot
         const newEmptySlot = createEmptySlot(tabId);


### PR DESCRIPTION
## Summary
- handle missing `.empty-slot` when audio loads

## Testing
- `node -e "console.log('no tests')"`

------
https://chatgpt.com/codex/tasks/task_e_687b28fbd098832f84c729cdcce26428