### PR TITLE
Fix orphaned audio elements on tab removal

### DIFF
--- a/script.js
+++ b/script.js
@@ -180,23 +180,16 @@ function createTab(name) {
 
 function removeTab(tabId) {
     if (tabData.size <= 1) return; // Don't remove last tab
-    
+
     // Stop all sounds in this tab
     const tab = tabData.get(tabId);
     if (tab) {
-        tab.sounds.forEach(sound => {
-            if (sound.audio) {
-                sound.audio.pause();
-                sound.audio.src = '';
-                if (sound.gainNode) sound.gainNode.disconnect();
-            }
-            if (sound.objectUrl) {
-                URL.revokeObjectURL(sound.objectUrl);
-                objectUrls.delete(sound.objectUrl);
-            }
-        });
+        // Use removeSound to properly clean up each sound
+        for (const id of Array.from(tab.sounds.keys())) {
+            removeSound(id, tabId);
+        }
     }
-    
+
     // Remove tab data and elements
     tabData.delete(tabId);
     document.querySelector(`[data-tab="${tabId}"]`).remove();


### PR DESCRIPTION
## Summary
- ensure audio elements are fully cleaned up when removing a tab

## Testing
- `npm test` *(fails: could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_687b2ddfa140832fbf47d6d8d260d9f7