### PR TITLE
Fix duplicate libraryData.clear call

### DIFF
--- a/script.js
+++ b/script.js
@@ -832,7 +832,6 @@ async function loadState() {
         libraryData.clear();
 
         let migrated = false;
-        libraryData.clear();
         if (Array.isArray(state.library)) {
             state.library.forEach(item => {
                 libraryData.set(item.id, { name: item.name });


### PR DESCRIPTION
## Summary
- cleanup: remove redundant libraryData.clear() in loadState

## Testing
- `git status --short`

------
https://chatgpt.com/codex/tasks/task_e_687b2ef5d590832f9c80a2b3157f1af4